### PR TITLE
Fixed undefined property error in PHP5.5.

### DIFF
--- a/classes/s3/request.php
+++ b/classes/s3/request.php
@@ -230,7 +230,10 @@ final class S3_Request
 		if ($this->response->code == 200 && $this->fp !== false)
 			return fwrite($this->fp, $data);
 		else
+		{
+			! isset($this->response->body) and $this->response->body = '';
 			$this->response->body .= $data;
+		}
 		return strlen($data);
 	}
 	


### PR DESCRIPTION
Undefined property error occurring in the PHP5.5.x.
Added processing so as to avoid the problem.
